### PR TITLE
Fix archetype translation detection

### DIFF
--- a/src/translator/build-converter.js
+++ b/src/translator/build-converter.js
@@ -80,8 +80,8 @@ export const convertJournals = (journalObject) => {
                     for (const feat of feats) {
                         feat.translation = featsTranslated.entries[feat.name];
                         feat.translated =
-                            feat.system.description.value.replaceAll(/@UUID[^\]]*]/g, "") !==
-                            feat.translation.description.replaceAll(/@UUID[^\]]*]/g, "");
+                            feat.system.description.value.replaceAll(/@UUID[^\]]*]({[^}]*})?/g, "") !==
+                            feat.translation.description.replaceAll(/@UUID[^\]]*]({[^}]*})?/g, "");
                     }
 
                     feats.sort((feat1, feat2) => {


### PR DESCRIPTION
Now, the brackets with the label are added during build, so we need to ignore them when checking for equality