### PR TITLE
Add fail-safe for missing Prerequisites

### DIFF
--- a/src/babele-register.js
+++ b/src/babele-register.js
@@ -150,6 +150,9 @@ Hooks.once("babele.init", () => {
                     game.langDePf2e.getMapping("heightening", true)
                 );
             },
+            translatePrerequisites: (data, translation) => {
+                return game.langDePf2e.translatePrerequisites(data, translation);
+            },
             translateRange: (data) => {
                 return game.langDePf2e.translateValue("range", data);
             },

--- a/src/translator/translator.js
+++ b/src/translator/translator.js
@@ -436,6 +436,28 @@ class Translator {
         }
     }
 
+    /**
+     * translate prerequisites and converts incomplete translation objects into arrays
+     * @param {[{ value: String }]} data
+     * @param {[{ value: String }] | { [number]: { value: String } }} translation
+     * @returns {[{ value: String }]}
+     */
+    translatePrerequisites(data = [], translation = []) {
+        if (!Object.keys(translation).length) return data;
+        if (!Array.isArray(translation)) {
+            Object.entries(translation).forEach(([index, v]) => {
+                data[index] = v;
+            });
+        }
+        else if (translation.length === data.length) return translation;
+        else {
+            translation.forEach((t, index) => {
+                data[index] = t;
+            })
+        }
+        return data;
+    }
+
     // Translate text labels provided in rule elements
     translateRules(data, translation) {
         if (translation) {

--- a/translation/de/compendium/pf2e.classfeatures.json
+++ b/translation/de/compendium/pf2e.classfeatures.json
@@ -3964,7 +3964,10 @@
       "converter": "translateDualLanguage",
       "path": "name"
     },
-    "prerequisites": "system.prerequisites.value",
+    "prerequisites": {
+      "converter": "translatePrerequisites",
+      "path": "system.prerequisites.value"
+    },
     "rules": {
       "converter": "translateRules",
       "path": "system.rules"

--- a/translation/de/compendium/pf2e.kingmaker-features.json
+++ b/translation/de/compendium/pf2e.kingmaker-features.json
@@ -637,7 +637,10 @@
       "converter": "translateDualLanguage",
       "path": "name"
     },
-    "prerequisites": "system.prerequisites.value",
+    "prerequisites": {
+      "converter": "translatePrerequisites",
+      "path": "system.prerequisites.value"
+    },
     "requirements": "system.requirements",
     "rules": {
       "converter": "translateRules",

--- a/translation/en/compendium/classfeatures.json
+++ b/translation/en/compendium/classfeatures.json
@@ -3964,7 +3964,10 @@
       "converter": "translateDualLanguage",
       "path": "name"
     },
-    "prerequisites": "system.prerequisites.value",
+    "prerequisites": {
+      "converter": "translatePrerequisites",
+      "path": "system.prerequisites.value"
+    },
     "rules": {
       "converter": "translateRules",
       "path": "system.rules"

--- a/translation/en/compendium/feats.json
+++ b/translation/en/compendium/feats.json
@@ -43534,7 +43534,10 @@
       "converter": "translateDualLanguage",
       "path": "name"
     },
-    "prerequisites": "system.prerequisites.value",
+    "prerequisites": {
+      "converter": "translatePrerequisites",
+      "path": "system.prerequisites.value"
+    },
     "rules": {
       "converter": "translateRules",
       "path": "system.rules"

--- a/translation/en/compendium/kingmaker-features.json
+++ b/translation/en/compendium/kingmaker-features.json
@@ -637,7 +637,10 @@
       "converter": "translateDualLanguage",
       "path": "name"
     },
-    "prerequisites": "system.prerequisites.value",
+    "prerequisites": {
+      "converter": "translatePrerequisites",
+      "path": "system.prerequisites.value"
+    },
     "requirements": "system.requirements",
     "rules": {
       "converter": "translateRules",


### PR DESCRIPTION
This adds a converter for Prerequisites that guarantees `prerequisites.value` is an Array.

---

I've ran into an issue with the Brazilian Portuguese localizaton where incomplete Prerequisite translations were formatted as Objects were replacing the `prerequisites.value` Array, which broke the system since it calls Array-specific functions.

Example: Missing first term of a prerequisite.
```js
const original = [{ value: "Foo Dedication" }, { value: "trained in Acrobatics" }];
const translation = {
  "1": { "value": "trained in Acrobatics" }
};
```